### PR TITLE
Remove blank header from markdown table

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 List of tech companies (or teams) that are based or working in Nepal :nepal:
 
-|     |     |     |     |     |     |     |     |     |
-|:-:  |:-:  |:-:  |:-:  |:-:  |:-:  |:-:  |:-:  |:-:  |
 | [A - C](#a---c) | [D - F](#d---f) | [G - I](#g---i) | [J - L](#j---l) | [M - O](#m---o) | [P - R](#p---r) | [S - U](#s---u) | [V - X](#v---x) | [Y - \#](#y---) |
+|:-:  |:-:  |:-:  |:-:  |:-:  |:-:  |:-:  |:-:  |:-:  |
+
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ List of tech companies (or teams) that are based or working in Nepal :nepal:
 | [A - C](#a---c) | [D - F](#d---f) | [G - I](#g---i) | [J - L](#j---l) | [M - O](#m---o) | [P - R](#p---r) | [S - U](#s---u) | [V - X](#v---x) | [Y - \#](#y---) |
 |:-:  |:-:  |:-:  |:-:  |:-:  |:-:  |:-:  |:-:  |:-:  |
 
-
 ### Contributing
 
 * Please open a [PR](https://guides.github.com/activities/forking/) for companies to be added


### PR DESCRIPTION
The markdown syntax you've used for generating table leaves a blank header above the cell. I've removed it.

You can compare the existing table with my change [here](https://github.com/studenton/tech-companies-in-nepal/blob/master/README.md) to visually see what I mean.